### PR TITLE
Line number in coverage report is shifted

### DIFF
--- a/src/main/java/jscover/instrument/sourcemap/SourceMapV3.java
+++ b/src/main/java/jscover/instrument/sourcemap/SourceMapV3.java
@@ -24,7 +24,7 @@ public class SourceMapV3 implements SourceMap {
 
     private void calculateValidLines() {
         sourceMapping.visitMappings((sourceName, symbolName, sourceStartPosition, startPosition, endPosition) -> {
-            int line = sourceStartPosition.getLine();
+            int line = sourceStartPosition.getLine() + 1;
             validLines.computeIfAbsent(sourceName, newKey -> new TreeSet<>()).add(line);
         });
     }


### PR DESCRIPTION
If i compare the coverage result with the original file, the covered lines are shifted and as a result the coverage is not correct.
This can be reproduced if you copy the original js files to the original-src folder, where at the moment only the minified files are present.